### PR TITLE
add warning banner for new login system migration

### DIFF
--- a/textpressocentral/TpC/TCNavWeb.cpp
+++ b/textpressocentral/TpC/TCNavWeb.cpp
@@ -199,6 +199,13 @@ session_("user=www-data dbname=www-data"), urlparameters_(urlparameters) {
     //
     Wt::WVBoxLayout * layout = new Wt::WVBoxLayout();
     setLayout(layout);
+    Wt::WAnchor *warning = new Wt::WAnchor(Wt::WLink(Wt::WLink::Url, "http://textmining.textpresso.org/new-login-system"));
+    Wt::WText *warningText = new Wt::WText("Textpresso will implement a new login system on May 1st, 2026! Please click here for important information!", warning);
+    warningText->decorationStyle().setForegroundColor(Wt::red);
+    warningText->decorationStyle().font().setWeight(Wt::WFont::Bold);
+    warningText->decorationStyle().font().setSize(Wt::WFont::Large);
+    layout->addWidget(warning);
+
     AuthEvent();
     if (urlparameters_->IsRoot()) {
 


### PR DESCRIPTION
Add a prominent warning banner to notify users about the upcoming login system change on May 1st, 2026 with a link to more information.