### PR TITLE
[codex] Redirect OAuth2 paths in Textpresso proxy

### DIFF
--- a/reverse_proxy/nginx.conf
+++ b/reverse_proxy/nginx.conf
@@ -127,6 +127,10 @@ http {
 
         # No rate limiting for general requests (API calls exempt)
 
+        location ^~ /oauth2 {
+           return 302 https://$host/tpc;
+        }
+
         location / {
            proxy_pass http://172.17.0.1:81;
            proxy_http_version 1.1;
@@ -176,6 +180,10 @@ http {
 
         # No rate limiting for general requests (API calls exempt)
 
+        location ^~ /oauth2 {
+           return 302 https://$host/tpc;
+        }
+
         location / {
            proxy_pass http://172.17.0.1:82;
            proxy_http_version 1.1;
@@ -223,6 +231,10 @@ http {
         }
 
         # No rate limiting for general requests (API calls exempt)
+
+        location ^~ /oauth2 {
+           return 302 https://$host/tpc;
+        }
 
         location / {
            proxy_pass http://172.17.0.1:83;
@@ -272,6 +284,10 @@ http {
 
         # No rate limiting for general requests (API calls exempt)
 
+        location ^~ /oauth2 {
+           return 302 https://$host/tpc;
+        }
+
         location / {
            proxy_pass http://172.17.0.1:84;
            proxy_http_version 1.1;
@@ -319,6 +335,10 @@ http {
         }
 
         # No rate limiting for general requests (API calls exempt)
+
+        location ^~ /oauth2 {
+           return 302 https://$host/tpc;
+        }
 
         location / {
            proxy_pass http://172.17.0.1:85;


### PR DESCRIPTION
## What changed

Adds an explicit `location ^~ /oauth2` redirect to each Textpresso reverse-proxy server block. If an OAuth callback path reaches nginx instead of being consumed by the ALB Cognito auth action, nginx now redirects the user to the clean `/tpc` entry point for the same host.

## Why

The normal ALB Cognito flow handles `/oauth2/idpresponse` before forwarding, but ALB logs showed a small number of stale or malformed `/oauth2/idpresponse` requests reaching the Textpresso backend and returning 404. Hans-Michael also clarified that `/oauth2` itself can break the app, not just the query parameters.

## Validation

Applied the same change on the production Textpresso instance and rebuilt only the `reverse_proxy` container.

- `docker exec reverse_proxy nginx -t` passed.
- Verified direct reverse-proxy responses for all five hosts redirect `/oauth2/idpresponse?code=test&state=test` to `https://<host>/tpc`.
- Confirmed the existing `/tpc` proxying configuration was otherwise unchanged.
